### PR TITLE
#15 product relationships

### DIFF
--- a/InventoryTracker/Data/Migrations/20260412212324_AddProductManufacturerRelationship.Designer.cs
+++ b/InventoryTracker/Data/Migrations/20260412212324_AddProductManufacturerRelationship.Designer.cs
@@ -4,6 +4,7 @@ using InventoryTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace InventoryTracker.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260412212324_AddProductManufacturerRelationship")]
+    partial class AddProductManufacturerRelationship
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/InventoryTracker/Data/Migrations/20260412212324_AddProductManufacturerRelationship.cs
+++ b/InventoryTracker/Data/Migrations/20260412212324_AddProductManufacturerRelationship.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace InventoryTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProductManufacturerRelationship : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/InventoryTracker/Data/Migrations/20260413013150_SyncRelationshipChanges.Designer.cs
+++ b/InventoryTracker/Data/Migrations/20260413013150_SyncRelationshipChanges.Designer.cs
@@ -4,6 +4,7 @@ using InventoryTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace InventoryTracker.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260413013150_SyncRelationshipChanges")]
+    partial class SyncRelationshipChanges
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/InventoryTracker/Data/Migrations/20260413013150_SyncRelationshipChanges.cs
+++ b/InventoryTracker/Data/Migrations/20260413013150_SyncRelationshipChanges.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace InventoryTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncRelationshipChanges : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ManufacturerId",
+                table: "Products",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Products_ManufacturerId",
+                table: "Products",
+                column: "ManufacturerId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Products_ManufacturerAccounts_ManufacturerId",
+                table: "Products",
+                column: "ManufacturerId",
+                principalTable: "ManufacturerAccounts",
+                principalColumn: "ManufacturerId",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Products_ManufacturerAccounts_ManufacturerId",
+                table: "Products");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Products_ManufacturerId",
+                table: "Products");
+
+            migrationBuilder.DropColumn(
+                name: "ManufacturerId",
+                table: "Products");
+        }
+    }
+}

--- a/InventoryTracker/Models/ManufacturerAccount.cs
+++ b/InventoryTracker/Models/ManufacturerAccount.cs
@@ -39,4 +39,9 @@ public class ManufacturerAccount
     [EmailAddress(ErrorMessage = "Invalid email address format.")]
     [StringLength(65, MinimumLength = 8, ErrorMessage = "Email must be between 8 and 65 characters.")]
     public required string ManufacturerEmail { get; set; }
+
+	/// <summary>
+	/// 
+	/// </summary>
+	public ICollection<Product> Products { get; set; } = new List<Product>();
 }

--- a/InventoryTracker/Models/ManufacturerAccount.cs
+++ b/InventoryTracker/Models/ManufacturerAccount.cs
@@ -33,15 +33,16 @@ public class ManufacturerAccount
     public required string Password { get; set; }
 
     /// <summary>
-    /// 
-    /// </summary>
+	/// The email of the manufacturer to contact.
+	/// </summary>
     [Required]
     [EmailAddress(ErrorMessage = "Invalid email address format.")]
     [StringLength(65, MinimumLength = 8, ErrorMessage = "Email must be between 8 and 65 characters.")]
     public required string ManufacturerEmail { get; set; }
 
 	/// <summary>
-	/// 
+	/// The collection of products produced by this manufacturer to represent the one-to-many 
+	/// relationship between ManufacturerAccount and Product. One Manufacturer has many Products.
 	/// </summary>
 	public ICollection<Product> Products { get; set; } = new List<Product>();
 }

--- a/InventoryTracker/Models/Product.cs
+++ b/InventoryTracker/Models/Product.cs
@@ -35,6 +35,9 @@ public class Product
 	[Required]
 	public int ManufacturerId { get; set; }
 
+	/// <summary>
+	/// Navigation property to the ManufacturerAccount that produces this product.
+	/// </summary>
 	[ForeignKey(nameof(ManufacturerId))]
 	public ManufacturerAccount? Manufacturer { get; set; }
 }

--- a/InventoryTracker/Models/Product.cs
+++ b/InventoryTracker/Models/Product.cs
@@ -28,4 +28,13 @@ public class Product
     /// The quantity of the item that is currently in stock.
     /// </summary>
     public int StockQuantity { get; set; }
+
+	/// <summary>
+	/// Relationship to the ManufacturerAccount that produces this product.
+	/// </summary>
+	[Required]
+	public int ManufacturerId { get; set; }
+
+	[ForeignKey(nameof(ManufacturerId))]
+	public ManufacturerAccount? Manufacturer { get; set; }
 }


### PR DESCRIPTION
Added one-to-many relationship between ManufacturerAccount and Product so that one manufacturer owns many product. This is done by adding a property to ManufacturerAccount for a list of Products, as well as adding properties to Product so that each product has a ManufacturerId and a navigation property of a ManufacturerAccount to each product.