### PR TITLE
Add product image property

### DIFF
--- a/InventoryTracker/InventoryTracker.csproj
+++ b/InventoryTracker/InventoryTracker.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <Folder Include="Pages\" />
+    <Folder Include="wwwroot\Images\Product\" />
   </ItemGroup>
 
 </Project>

--- a/InventoryTracker/Models/Product.cs
+++ b/InventoryTracker/Models/Product.cs
@@ -57,13 +57,11 @@ public class Product
 	/// <summary>
 	/// Relationship to the WholesalerAccount that sells this product.
 	/// </summary>
-	[Required]
-	public int WholesalerId { get; set; }
+	public int? WholesalerId { get; set; }
 
 	/// <summary>
 	/// Navigaion property of the collection of WholesalerAccounts that sell this product.
 	/// </summary>
-	[Required]
 	[ForeignKey(nameof(WholesalerId))]
 	public WholesalerAccount? Wholesaler { get; set; }
 }

--- a/InventoryTracker/Models/Product.cs
+++ b/InventoryTracker/Models/Product.cs
@@ -42,6 +42,11 @@ public class Product
 	public int StockQuantity { get; set; }
 
 	/// <summary>
+	/// The file path to the associated image of the product, if any.
+	/// </summary>
+	public string? ImagePath { get; set; }
+
+	/// <summary>
 	/// Relationship to the ManufacturerAccount that produces this product.
 	/// </summary>
 	[Required]


### PR DESCRIPTION
Closes #25 

Configured Product class to now have an image property that contains a string of the path of the image. Images for products are to be stored in wwwroot/Images/Product. Also adjusted Product properties to include some products having no wholesaler by making the WholesalerId and Wholesaler navigation property nullable.